### PR TITLE
添加网页版 M3U 播放器

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,7 @@
 |Kodi|https://kodi.tv/|全平台|
 |Potplayer|https://potplayer.tv/|Windows|
 |IPTV Player|https://iptvplayer.stream|Web|
+|Free IPTV Player|https://freeiptvplayer.net/iptv-player/|Web，可加载 M3U URL 或上传 M3U 文件|
 
 ok影视删库，ok影视fork：https://github.com/lystv/fmapp/tree/ok/apk/release
 


### PR DESCRIPTION
## 说明

在“推荐软件 → 空壳软件”表格中增加 Free IPTV Player。

该工具可直接在浏览器中加载 M3U URL 或上传 M3U 文件，不提供频道或播放列表，也无需安装软件。核心播放器无需登录即可使用；页面含广告。

## 验证

- 播放器页面返回 HTTP 200
- 已确认页面提供 M3U URL 输入框和 M3U 文件上传框
- `git diff --check` 通过

## 关系披露

此提交由该站点运营方委托创建。
